### PR TITLE
Fix for Heroku-24 stack; run install and build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ You'll need a [`Procfile`](https://devcenter.heroku.com/articles/procfile) in th
 
 Pin a certain Bun version with a `runtime.bun.txt` or `runtime.txt` with e.g. `v1.0.7` in it.
 
+## Support scripts
+
+This buildpack automatically runs the following bun commands and scripts if defined in `package.json`.
+
+- install (`bun install`)
+- build (`bun run build`)
+- heroku:postbuild (`bun run heroku-postbuild`)
+
 ## Binding to correct port
 
 Bind to `env.PORT` eg

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Heroku buildpack for [Bun.js](https://bun.sh/) - allows you to run Bun on Heroku.
 
-Largely copied from the [Deno buildpack](https://github.com/chibat/heroku-buildpack-deno).
+Largely copied from the [Deno buildpack](https://github.com/chibat/heroku-buildpack-deno) and [Node.js buildpack](https://github.com/heroku/heroku-buildpack-nodejs).
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Pin a certain Bun version with a `runtime.bun.txt` or `runtime.txt` with e.g. `v
 This buildpack automatically runs the following bun commands and scripts if defined in `package.json`.
 
 - install (`bun install`)
+- heroku-prebuild (`bun run heroku-prebuild`)
 - build (`bun run build`)
-- heroku:postbuild (`bun run heroku-postbuild`)
+- heroku-postbuild (`bun run heroku-postbuild`)
 
 ## Binding to correct port
 

--- a/bin/compile
+++ b/bin/compile
@@ -58,3 +58,10 @@ then
   echo "Building application..."
   bun run build
 fi
+
+has_heroku_postbuild_script=$(has_script "package.json" "heroku-postbuild")
+if [[ "$has_heroku_postbuild_script" == "true" ]]
+then
+  echo "Running Heroku postbuild script..."
+  bun run heroku-postbuild
+fi

--- a/bin/compile
+++ b/bin/compile
@@ -64,6 +64,7 @@ if [[ "$has_build_script" == "true" ]]
 then
   echo "Building application..."
   bun run build
+  echo "Done building application..."
 fi
 
 has_heroku_postbuild_script=$(has_script "package.json" "heroku-postbuild")

--- a/bin/compile
+++ b/bin/compile
@@ -43,11 +43,12 @@ echo 'export BUN_DIR="$HOME/.heroku/cache"' >> $PROFILE_PATH
 
 set +e
 
+cd $BUILD_DIR
+
 # download dependencies
 if [ -f package.json ]
 then
   echo "Installing dependencies..."
-  cd $BUILD_DIR
   bun install
 fi
 
@@ -55,7 +56,6 @@ has_build_script=$(has_script "package.json" "build")
 if [[ "$has_build_script" == "true" ]]
 then
   echo "Building application..."
-  cd $BUILD_DIR
   bun run build
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -45,6 +45,8 @@ then
   cd $BUILD_DIR
   bun install
 
-  echo "Building application..."
-  bun run build
+  if grep -q '"build"\s*:' package.json; then
+    echo "Building application..."
+    bun run build
+  fi
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -44,9 +44,12 @@ then
   echo "Installing dependencies..."
   cd $BUILD_DIR
   bun install
+fi
 
-  if grep -q '"build"\s*:' package.json; then
-    echo "Building application..."
-    bun run build
-  fi
+has_build_script=$(has_script "package.json" "build")
+if [[ "$has_build_script" == "true" ]]
+then
+  echo "Building application..."
+  cd $BUILD_DIR
+  bun run build
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -52,6 +52,13 @@ then
   bun install
 fi
 
+has_heroku_prebuild_script=$(has_script "package.json" "heroku-prebuild")
+if [[ "$has_heroku_prebuild_script" == "true" ]]
+then
+  echo "Running Heroku prebuild script..."
+  bun run heroku-prebuild
+fi
+
 has_build_script=$(has_script "package.json" "build")
 if [[ "$has_build_script" == "true" ]]
 then

--- a/bin/compile
+++ b/bin/compile
@@ -58,3 +58,5 @@ then
   cd $BUILD_DIR
   bun run build
 fi
+
+ls $BUILD_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ HEROKU_DIR=$BUILD_DIR/.heroku
 BIN_DIR=$HEROKU_DIR/bin
 
 # To enable the local source build cache path, copy the files and match the build path with the startup path.
-cp -rpT $BUILD_DIR $HOME
+cp -rp $BUILD_DIR $HOME
 cd $HOME
 
 if [ -f runtime.bun.txt ]

--- a/bin/compile
+++ b/bin/compile
@@ -44,4 +44,7 @@ then
   echo "Installing dependencies..."
   cd $BUILD_DIR
   bun install
+
+  echo "Building application..."
+  bun run build
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -7,6 +7,11 @@ set -e
 BUILD_DIR=${1:-.}
 CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
+BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
+
+### Load dependencies
+source "$BP_DIR/lib/json.sh"
+
 
 HEROKU_DIR=$BUILD_DIR/.heroku
 BIN_DIR=$HEROKU_DIR/bin

--- a/bin/compile
+++ b/bin/compile
@@ -58,5 +58,3 @@ then
   echo "Building application..."
   bun run build
 fi
-
-ls $BUILD_DIR

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -1,0 +1,52 @@
+# !/usr/bin/env bash
+# https://github.com/heroku/heroku-buildpack-nodejs/blob/main/lib/json.sh
+
+read_json() {
+  local file="$1"
+  local key="$2"
+
+  if test -f "$file"; then
+    # -c = print on only one line
+    # -M = strip any color
+    # --raw-output = if the filter’s result is a string then it will be written directly
+    #                to stdout rather than being formatted as a JSON string with quotes
+    # shellcheck disable=SC2002
+    cat "$file" | jq -c -M --raw-output "$key // \"\"" || return 1
+  else
+    echo ""
+  fi
+}
+
+json_has_key() {
+  local file="$1"
+  local key="$2"
+
+  if test -f "$file"; then
+    # shellcheck disable=SC2002
+    cat "$file" | jq ". | has(\"$key\")"
+  else
+    echo "false"
+  fi
+}
+
+has_script() {
+  local file="$1"
+  local key="$2"
+
+  if test -f "$file"; then
+    # shellcheck disable=SC2002
+    cat "$file" | jq ".[\"scripts\"] | has(\"$key\")"
+  else
+    echo "false"
+  fi
+}
+
+is_invalid_json_file() {
+  local file="$1"
+  # shellcheck disable=SC2002
+  if ! cat "$file" | jq "." 1>/dev/null; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}


### PR DESCRIPTION
From @noxan

- fixes https://github.com/jakeg/heroku-buildpack-bun/issues/6 by removing `-T` flag from `cp`
- runs scripts from `package.json` (`install`, `heroku-prebuild`, `build`, `heroku-postbuild`)
- should fix https://github.com/jakeg/heroku-buildpack-bun/issues/2