### PR TITLE
Add default process type if no Procfile

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,1 +1,8 @@
 #!/usr/bin/env bash
+
+cat << EOF
+---
+addons: []
+default_process_types:
+  web: bun start
+EOF


### PR DESCRIPTION
Fixes #4 by defaulting to `bun start` if no `Procfile`