### PR TITLE
Fail pipe command failures

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -2,7 +2,7 @@
 # bin/compile <build-dir> <cache-dir> <env-dir>
 # $HOME: /app
 
-set -e
+set -euo pipefail
 
 BUILD_DIR=${1:-.}
 CACHE_DIR=${2:-}


### PR DESCRIPTION
We ran into a situation where the curl command failed, but our build succeeded. We were left with a deployment that was missing all of our javascript files meant to be compiled by bun, but the `bun` command was not found.

I believe this is because the `curl` download is piped into `bash`, then the `bash` command is marked as a success.

`set -o pipefail` will return the exit code from the first failed command, so a failed download will be recognized as a failure.

The `set -u` command tells bash to treat unset variables as an error and exit immediately. This is unrelated to the above, but would make the Bash script a bit safer.

Some posts I used for education
- https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
- http://redsymbol.net/articles/unofficial-bash-strict-mode/

A tool recommended to me by a Heroku buildpack engineer (big thanks to Ed)
- [Shell script linter](https://github.com/koalaman/shellcheck)

I believe there are other improvements we could make to this, such as automatically retrying the `curl` request. [Here's an example from Heroku's Python buildpack.](https://github.com/heroku/heroku-buildpack-python/blob/99684a6ffdb23e50a9a2ee0b59ddf3c5e865ea5d/bin/steps/python#L115)