### PR TITLE
correct the bunx symlink after copying from a temporary location

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -56,6 +56,9 @@ export BUN_DIR=$BUILD_DIR/.heroku/cache
 curl -fsSL --retry-connrefused --retry 3 https://bun.sh/install | bash $BUN_INSTALL_VERSION
 export PATH="$BUN_INSTALL/bin:$PATH"
 
+# the bunx symlink might point to the absolute path (e.g. /tmp/build_45505a2e/.heroku/bin/bun), so it should be fixed
+ln -sfr -T $BUN_INSTALL/bin/bun $BUN_INSTALL/bin/bunx
+
 # set environment variables at runtime
 PROFILE_PATH="$BUILD_DIR/.profile.d/bun.sh"
 mkdir -p $(dirname $PROFILE_PATH)


### PR DESCRIPTION
When I tried to use `bunx` inside of a dyno I've received an error message: `bunx: command not found`. So I ran bash in the dyno to investigate further and found that the `bunx` symlink had an unexpected target:
```
~/.heroku/bin $ ls -alh
total 96M
drwx------ 2 u25940 dyno 4.0K Apr 24 11:03 .
drwx------ 4 u25940 dyno 4.0K Apr 24 11:03 ..
-rwx------ 1 u25940 dyno  96M Apr  9 06:06 bun
lrwxrwxrwx 1 u25940 dyno   35 Apr 24 11:03 bunx -> /tmp/build_63f1de94/.heroku/bin/bun
```

This PR attempts to fix this issue by setting the symlink to `bun` (a relative target) so the directory looks as follows:
```
~ $ ls -alh .heroku/bin/
total 96M
drwx------ 2 u17071 dyno 4.0K Apr 24 12:01 .
drwx------ 4 u17071 dyno 4.0K Apr 24 11:34 ..
-rwx------ 1 u17071 dyno  96M Apr  9 06:06 bun
lrwxrwxrwx 1 u17071 dyno    3 Apr 24 12:01 bunx -> bun
```
And after these changes `bunx` works.